### PR TITLE
Linux Static Compilation Target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ WIN=windows-agent.exe
 FLAGS=-ldflags "-s -w"
 WIN-FLAGS=-ldflags -H=windowsgui
 
-all: clean create-directory agent-windows agent-linux
+all: clean create-directory agent-windows agent-linux agent-linux-static
 
 create-directory:
 	mkdir ${DIRECTORY}
@@ -17,5 +17,9 @@ agent-linux:
 	echo "Compiling Linux binary"
 	env GOOS=linux GOARCH=amd64 go build ${FLAGS} -o ${DIRECTORY}/${LINUX} main.go
 
+agent-linux-static:
+	echo "Compiling static Linux binary"
+	docker run --rm=true -itv $(PWD):/mnt alpine:3.7 /mnt/build_static.sh
+	
 clean:
 	rm -rf ${DIRECTORY}

--- a/build_static.sh
+++ b/build_static.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# many thanks to @negbie
+# https://github.com/google/gopacket/issues/424#issuecomment-369551841
+set -ex
+apk update
+apk add linux-headers musl-dev gcc go libpcap-dev ca-certificates git
+
+mkdir /go
+export GOPATH=/go
+mkdir -p /go/src/github.com/emmaunel
+mkdir -p /mnt/out
+cp -a /mnt /go/src/github.com/emmaunel/vishnu
+cd /go/src/github.com/emmaunel/vishnu
+rm -f vishnu*
+go get -v ./ ./
+go build --ldflags '-linkmode external -extldflags "-static -s -w"' -v ./
+cp ./vishnu /mnt/out/

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vishnu
+module github.com/emmaunel/vishnu
 
 go 1.17
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"strconv"
 
-	"vishnu/spec"
+	"github.com/emmaunel/vishnu/spec"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"


### PR DESCRIPTION
Often libpcap is not installed on the target machine, and the version that you can install might not match what Vishnu is compiled with.

This PR adds a static target to the makefile. You can develop locally with the regular dynamic target and then compile the final release with the new static one.

The target calls a script that builds the implant in an Alpine container with musl, to avoid libnss/getaddrinfo woes. More info on that [here](https://stackoverflow.com/questions/2725255/create-statically-linked-binary-that-uses-getaddrinfo).

The script is pulled from [here](https://github.com/google/gopacket/issues/424#issuecomment-369551841), many thanks to negbie.

This also changes the module name to point to the GitHub repository. Currently this points to github.com/emmaunel/vishnu, but I can change it to point to RITRedteam if we want to use that going forward.

I tested this on Ubuntu 18.04, UB's network and it executed. Hope this helps.
